### PR TITLE
bump: workflows to 1.8.1 and torch to 2.2.2

### DIFF
--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -25,24 +25,24 @@ jobs:
           - os: 'MacOS-latest'
             pytorch-dtype: 'float64'
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.6.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.8.1
     with:
       os: ${{ matrix.os }}
       python-version: '["3.8", "3.11"]'
-      pytorch-version: '["1.9.1", "2.2.0"]'
+      pytorch-version: '["1.9.1", "2.2.2"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
 
   coverage:
-    uses: kornia/workflows/.github/workflows/coverage.yml@v1.6.0
+    uses: kornia/workflows/.github/workflows/coverage.yml@v1.8.1
 
   typing:
-    uses: kornia/workflows/.github/workflows/mypy.yml@v1.6.0
+    uses: kornia/workflows/.github/workflows/mypy.yml@v1.8.1
 
   tutorials:
-    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.6.0
+    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.8.1
 
   docs:
-    uses: kornia/workflows/.github/workflows/docs.yml@v1.6.0
+    uses: kornia/workflows/.github/workflows/docs.yml@v1.8.1
 
   collector:
     needs: [coverage, tests-cpu, tutorials, typing, docs]
@@ -63,7 +63,7 @@ jobs:
         os: ['Ubuntu-latest', 'Windows-latest'] #, 'MacOS-latest'] add it when https://github.com/pytorch/pytorch/pull/89262 be merged
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.6.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.8.1
     with:
       os: ${{ matrix.os }}
       pytorch-version: '["nightly"]'

--- a/.github/workflows/scheduled_test_cpu.yml
+++ b/.github/workflows/scheduled_test_cpu.yml
@@ -18,11 +18,11 @@ jobs:
         # os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.6.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.8.1
     with:
       os: 'Ubuntu-latest'
       python-version: '["3.8", "3.9", "3.10", "3.11"]'
-      pytorch-version: '["1.9.1", "1.10.2", "1.11.0", "1.12.1", "1.13.1", "2.0.1", "2.1.2", "2.2.0"]'
+      pytorch-version: '["1.9.1", "1.10.2", "1.11.0", "1.12.1", "1.13.1", "2.0.1", "2.1.2", "2.2.2"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
       pytest-extra: '--runslow'
 
@@ -34,11 +34,11 @@ jobs:
       matrix:
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.6.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.8.1
     with:
       os: 'Windows-latest'
       python-version: '["3.11"]'
-      pytorch-version: '["1.9.1", "2.2.0"]'
+      pytorch-version: '["1.9.1", "2.2.2"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
 
   tests-cpu-mac:
@@ -47,19 +47,19 @@ jobs:
       matrix:
         pytorch-dtype: ['float32', 'float64']
 
-    uses: kornia/workflows/.github/workflows/tests.yml@v1.6.0
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.8.1
     with:
       os: 'MacOS-latest'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
 
   coverage:
-    uses: kornia/workflows/.github/workflows/coverage.yml@v1.6.0
+    uses: kornia/workflows/.github/workflows/coverage.yml@v1.8.1
 
   typing:
-    uses: kornia/workflows/.github/workflows/mypy.yml@v1.6.0
+    uses: kornia/workflows/.github/workflows/mypy.yml@v1.8.1
 
   tutorials:
-    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.6.0
+    uses: kornia/workflows/.github/workflows/tutorials.yml@v1.8.1
 
   docs:
-    uses: kornia/workflows/.github/workflows/docs.yml@v1.6.0
+    uses: kornia/workflows/.github/workflows/docs.yml@v1.8.1


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request number 2888 from kornia/kornia.



The original branch is fork-2888-johnnv1/bump-pytorch