### PR TITLE
CI: Drop macos-latest runner for torch 1.9.1

### DIFF
--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -24,7 +24,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: '["3.8", "3.11"]'
-      pytorch-version: '["1.9.1", "2.2.0"]'
+      pytorch-version: '["1.9.1", "2.2.2"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
 
   tests-cpu-macos:
@@ -32,7 +32,6 @@ jobs:
     with:
       os: 'MacOS-latest'
       python-version: '["3.8", "3.11"]'
-      pytorch-version: '["2.2.0"]'
       pytorch-dtype: 'float32'
 
 

--- a/.github/workflows/pr_test_cpu.yml
+++ b/.github/workflows/pr_test_cpu.yml
@@ -17,13 +17,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ['Ubuntu-latest', 'Windows-latest', 'MacOS-latest']
+        os: ['Ubuntu-latest', 'Windows-latest']
         pytorch-dtype: ['float32', 'float64']
-        exclude:
-          - os: 'Windows-latest'
-            pytorch-dtype: 'float64'
-          - os: 'MacOS-latest'
-            pytorch-dtype: 'float64'
 
     uses: kornia/workflows/.github/workflows/tests.yml@v1.6.0
     with:
@@ -31,6 +26,15 @@ jobs:
       python-version: '["3.8", "3.11"]'
       pytorch-version: '["1.9.1", "2.2.0"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
+
+  tests-cpu-macos:
+    uses: kornia/workflows/.github/workflows/tests.yml@v1.6.0
+    with:
+      os: 'MacOS-latest'
+      python-version: '["3.8", "3.11"]'
+      pytorch-version: '["2.2.0"]'
+      pytorch-dtype: 'float32'
+
 
   coverage:
     uses: kornia/workflows/.github/workflows/coverage.yml@v1.6.0

--- a/.github/workflows/scheduled_test_cpu.yml
+++ b/.github/workflows/scheduled_test_cpu.yml
@@ -22,7 +22,7 @@ jobs:
     with:
       os: 'Ubuntu-latest'
       python-version: '["3.8", "3.9", "3.10", "3.11"]'
-      pytorch-version: '["1.9.1", "1.10.2", "1.11.0", "1.12.1", "1.13.1", "2.0.1", "2.1.2", "2.2.0"]'
+      pytorch-version: '["1.9.1", "1.10.2", "1.11.0", "1.12.1", "1.13.1", "2.0.1", "2.1.2", "2.2.2"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
       pytest-extra: '--runslow'
 
@@ -38,7 +38,7 @@ jobs:
     with:
       os: 'Windows-latest'
       python-version: '["3.11"]'
-      pytorch-version: '["1.9.1", "2.2.0"]'
+      pytorch-version: '["1.9.1", "2.2.2"]'
       pytorch-dtype: ${{ matrix.pytorch-dtype }}
 
   tests-cpu-mac:


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [kornia/kornia#2905](https://togithub.com/kornia/kornia/pull/2905).



The original branch is fork-2905-johnnv1/drop/macos-pt-old