### PR TITLE
chore (dev deps): pin numpy to lower than 2.0

### DIFF
--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,6 +1,6 @@
 coverage
 mypy
-numpy
+numpy<2
 onnx
 pre-commit>=2
 pytest==8.2.2


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [kornia/kornia#2937](https://togithub.com/kornia/kornia/pull/2937).



The original branch is fork-2937-johnnv1/chore/pin-numpy