### PR TITLE
Replace deprecated torch.cuda.amp decorator

### DIFF
--- a/kornia/contrib/models/efficient_vit/nn/ops.py
+++ b/kornia/contrib/models/efficient_vit/nn/ops.py
@@ -8,7 +8,17 @@ from __future__ import annotations
 import torch
 import torch.nn.functional as F
 from torch import nn
-from torch.cuda.amp import autocast
+
+from kornia.utils._compat import torch_version_ge
+
+if torch_version_ge(2, 4):
+    from functools import partial
+
+    from torch.amp import autocast as _autocast
+
+    autocast = partial(_autocast, "cuda")
+else:
+    from torch.cuda.amp import autocast
 
 from kornia.contrib.models.efficient_vit.nn.act import build_act
 from kornia.contrib.models.efficient_vit.nn.norm import build_norm

--- a/kornia/contrib/models/efficient_vit/nn/ops.py
+++ b/kornia/contrib/models/efficient_vit/nn/ops.py
@@ -9,20 +9,10 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-from kornia.utils._compat import torch_version_ge
-
-if torch_version_ge(2, 4):
-    from functools import partial
-
-    from torch.amp import autocast as _autocast
-
-    autocast = partial(_autocast, "cuda")
-else:
-    from torch.cuda.amp import autocast
-
 from kornia.contrib.models.efficient_vit.nn.act import build_act
 from kornia.contrib.models.efficient_vit.nn.norm import build_norm
 from kornia.contrib.models.efficient_vit.utils import get_same_padding, val2tuple
+from kornia.utils._compat import autocast
 
 __all__ = [
     "ConvLayer",

--- a/kornia/feature/lightglue.py
+++ b/kornia/feature/lightglue.py
@@ -2,11 +2,11 @@ import math
 import warnings
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple
-from mypy_extensions import DefaultNamedArg
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
+from mypy_extensions import DefaultNamedArg
 from torch import nn
 
 from kornia.core import (
@@ -38,12 +38,14 @@ if FlashCrossAttention or hasattr(F, "scaled_dot_product_attention"):
 else:
     FLASH_AVAILABLE = False
 
-if torch_version_ge(2, 4):
+if TYPE_CHECKING:  # TODO (@johnnv1): remove this branch when bump the pytorch CI to support torch 2.4
+    from torch.cuda.amp import custom_fwd
+elif torch_version_ge(2, 4):
     from functools import partial
 
     from torch.amp import custom_fwd as _custom_fwd
 
-    custom_fwd: Callable[[DefaultNamedArg(Any, 'cast_inputs')], Any] = partial(_custom_fwd, device_type="cuda")
+    custom_fwd: Callable[[DefaultNamedArg(Any, "cast_inputs")], Any] = partial(_custom_fwd, device_type="cuda")
 else:
     from torch.cuda.amp import custom_fwd
 

--- a/kornia/feature/lightglue.py
+++ b/kornia/feature/lightglue.py
@@ -3,6 +3,7 @@ import warnings
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple
+from mypy_extensions import DefaultNamedArg
 
 import torch
 import torch.nn.functional as F
@@ -42,7 +43,7 @@ if torch_version_ge(2, 4):
 
     from torch.amp import custom_fwd as _custom_fwd
 
-    custom_fwd = partial(_custom_fwd, device_type="cuda")
+    custom_fwd: Callable[[DefaultNamedArg(Any, 'cast_inputs')], Any] = partial(_custom_fwd, device_type="cuda")
 else:
     from torch.cuda.amp import custom_fwd
 

--- a/kornia/feature/lightglue.py
+++ b/kornia/feature/lightglue.py
@@ -2,11 +2,10 @@ import math
 import warnings
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Optional, Tuple
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
-from mypy_extensions import DefaultNamedArg
 from torch import nn
 
 from kornia.core import (
@@ -26,7 +25,7 @@ from kornia.core import (
 )
 from kornia.core.check import KORNIA_CHECK
 from kornia.feature.laf import laf_to_three_points, scale_laf
-from kornia.utils._compat import torch_version_ge
+from kornia.utils._compat import custom_fwd
 
 try:
     from flash_attn.modules.mha import FlashCrossAttention
@@ -37,17 +36,6 @@ if FlashCrossAttention or hasattr(F, "scaled_dot_product_attention"):
     FLASH_AVAILABLE = True
 else:
     FLASH_AVAILABLE = False
-
-if TYPE_CHECKING:  # TODO (@johnnv1): remove this branch when bump the pytorch CI to support torch 2.4
-    from torch.cuda.amp import custom_fwd
-elif torch_version_ge(2, 4):
-    from functools import partial
-
-    from torch.amp import custom_fwd as _custom_fwd
-
-    custom_fwd: Callable[[DefaultNamedArg(Any, "cast_inputs")], Any] = partial(_custom_fwd, device_type="cuda")
-else:
-    from torch.cuda.amp import custom_fwd
 
 
 def math_clamp(x, min_, max_):  # type: ignore


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [kornia/kornia#2967](https://togithub.com/kornia/kornia/pull/2967).



The original branch is fork-2967-loichuder/cuda-amp-deprecated