### PR TITLE
Bump pytest from 8.2.2 to 8.3.2

### DIFF
--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -4,6 +4,6 @@ numpy<3
 onnx
 pillow
 pre-commit>=2
-pytest==8.2.2
+pytest==8.3.2
 pytest-timeout
 requests


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [kornia/kornia#2968](https://togithub.com/kornia/kornia/pull/2968).



The original branch is upstream/dependabot/pip/pytest-8.3.2