### PR TITLE
Bump actions/download-artifact from 2 to 4.1.7 in /.github/workflows

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -33,7 +33,7 @@ jobs:
     needs: build-sdist
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4.1.7
       with:
         name: pypi-packages-${{ github.sha }}
         path: dist
@@ -55,7 +55,7 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: 3.8
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4.1.7
       with:
         name: pypi-packages-${{ github.sha }}
         path: dist


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [kornia/kornia#3011](https://togithub.com/kornia/kornia/pull/3011).



The original branch is upstream/dependabot/github_actions/dot-github/workflows/actions/download-artifact-4.1.7