### PR TITLE
chore(deps-dev): bump pytest from 8.3.2 to 8.3.3

### DIFF
--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -6,7 +6,7 @@ numpy<2
 onnx
 pillow
 pre-commit>=2
-pytest==8.3.2
+pytest==8.3.3
 pytest-timeout
 requests
 transformers


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [kornia/kornia#3021](https://togithub.com/kornia/kornia/pull/3021).



The original branch is upstream/dependabot/pip/pytest-8.3.3